### PR TITLE
Added code to add label to reference organ

### DIFF
--- a/ctpop_plots/PlotsPaper.R
+++ b/ctpop_plots/PlotsPaper.R
@@ -316,9 +316,14 @@ rui_count = more_cols %>% count (as_id)
 more_cols = merge(more_cols, rui_count, by.x = "as_id")
 colnames(more_cols)[colnames(more_cols) == "n"] <- "rui_locations_per_as"
 
-p = ggplot(more_cols, aes(x = reorder(as_label, -intersection_volume), y = intersection_volume, fill=sex, alpha = rui_locations_per_as))+
+# add tissue_block_intersection_percentage
+with_ratio = more_cols %>% mutate(
+  tissue_block_intersection_percentage = intersection_volume/tissue_block_volume
+)
+
+p = ggplot(with_ratio, aes(x = organ_label, y = tissue_block_intersection_percentage, fill=sex, alpha = rui_locations_per_as))+
   geom_bar(stat = "identity")+
-  facet_wrap(~organ)+
+  # facet_wrap(~organ_label)+
   scale_y_continuous(labels=scales::number_format(decimal.mark = '.'))+
   scale_color_brewer()+
   scale_fill_brewer(type="qual", palette = "Dark2")+

--- a/data-processor/queries/table-s5.rq
+++ b/data-processor/queries/table-s5.rq
@@ -15,8 +15,11 @@ PREFIX dc: <http://purl.org/dc/terms/>
 PREFIX hubmap: <https://entity.api.hubmapconsortium.org/entities/>
 PREFIX rui: <http://purl.org/ccf/1.5/>
 
-SELECT DISTINCT ?rui_location ?organ ?as_label ?as_id ?intersection_volume ?as_volume ?tissue_block_volume
+SELECT DISTINCT ?rui_location ?organ ?organ_label ?as_label ?as_id ?intersection_volume ?as_volume ?tissue_block_volume
+
 FROM ctpop-graph:
+FROM <https://purl.org/ccf/releases/2.2.1/ccf.owl>
+
 WHERE {
 
 	    # Get tissue block volume
@@ -36,8 +39,16 @@ WHERE {
 					ccf:has_reference_organ ?ref_organ ;
 					ccf:percentage_of_total ?percentage ;
     	]
-    ]
+    ] .
+
+	# get label for reference organ
+	?refOrgan ccf:representation_of ?organId .
+    ?organId rdfs:label ?organ_label
+
 		BIND (?tissue_block_volume * ?percentage as ?intersection_volume)
   	BIND (REPLACE(REPLACE(REPLACE(STR(?ref_organ), "http://purl.org/ccf/latest/ccf.owl#", ""), "Colon", "LargeIntestine"), "V1.1", "") as ?organ)
+
+
+
 }
 ORDER BY ?organ ?rui_location DESC(?as_volume)

--- a/data-processor/queries/table-s5.rq
+++ b/data-processor/queries/table-s5.rq
@@ -42,7 +42,7 @@ WHERE {
     ] .
 
 	# get label for reference organ
-	?refOrgan ccf:representation_of ?organId .
+	?ref_organ ccf:representation_of ?organId .
     ?organId rdfs:label ?organ_label
 
 		BIND (?tissue_block_volume * ?percentage as ?intersection_volume)

--- a/data/reports/table-s5.csv
+++ b/data/reports/table-s5.csv
@@ -1,276 +1,276 @@
-rui_location,organ,as_label,as_id,intersection_volume,as_volume,tissue_block_volume
-http://purl.org/ccf/1.5/bf67cdbe-2af0-478e-af80-14e593bdbde1,VHFAllenBrain,middle temporal gyrus,http://purl.obolibrary.org/obo/UBERON_0002771,95.39999999999999,21669.14,100
-http://purl.org/ccf/1.5/04baf323-eda0-4f72-bea1-aa943aa70894,VHFHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,3862.528,229312.8,4096
-http://purl.org/ccf/1.5/05c11830-1526-4472-bd12-ea24dbcfd3cc,VHFHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,3549.1499999999996,229312.8,7425
-http://purl.org/ccf/1.5/05c11830-1526-4472-bd12-ea24dbcfd3cc,VHFHeart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,883.5749999999999,78714.76,7425
-http://purl.org/ccf/1.5/05c11830-1526-4472-bd12-ea24dbcfd3cc,VHFHeart,interventricular septum,http://purl.obolibrary.org/obo/UBERON_0002094,5531.625,65894.53,7425
-http://purl.org/ccf/1.5/05c11830-1526-4472-bd12-ea24dbcfd3cc,VHFHeart,Posteromedial head of posterior papillary muscle of left ventricle,http://purl.org/sig/ont/fma/fma7267,631.125,4401.499,7425
-http://purl.org/ccf/1.5/16e98d8c-8983-48c2-bb41-7b1cfbbf2e4a,VHFHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,2670.122,229312.8,3094
-http://purl.org/ccf/1.5/1995aefd-5289-4652-a7e0-cc66c495649f,VHFHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1491.7630000000001,229312.8,2197
-http://purl.org/ccf/1.5/1995aefd-5289-4652-a7e0-cc66c495649f,VHFHeart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,347.126,78714.76,2197
-http://purl.org/ccf/1.5/1995aefd-5289-4652-a7e0-cc66c495649f,VHFHeart,interventricular septum,http://purl.obolibrary.org/obo/UBERON_0002094,127.426,65894.53,2197
-http://purl.org/ccf/1.5/1fe61622-ba53-47c9-967e-e764c21b8189,VHFHeart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,2023.1999999999998,78714.76,2400
-http://purl.org/ccf/1.5/2156f837-2ab2-4305-8e7f-8084249e91cd,VHFHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,2687.1600000000003,229312.8,2940
-http://purl.org/ccf/1.5/2816c343-c908-45bf-8964-974b1c54a5b9,VHFHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,3862.528,229312.8,4096
-http://purl.org/ccf/1.5/53b083ab-cb70-4096-b385-85590ddc370c,VHFHeart,left cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002079,553.3919999999999,18115.97,4536
-http://purl.org/ccf/1.5/53b083ab-cb70-4096-b385-85590ddc370c,VHFHeart,aortic valve,http://purl.obolibrary.org/obo/UBERON_0002137,22.68,3612.979,4536
-http://purl.org/ccf/1.5/9abfed4e-2fde-4d80-a8aa-7439a106d895,VHFHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,6972.4800000000005,229312.8,8640
-http://purl.org/ccf/1.5/9f2c1d5d-2ad4-4a7a-ad95-622c7328b554,VHFHeart,right cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002078,2096.64,33225.9,4368
-http://purl.org/ccf/1.5/a04e60c6-693a-4c25-a069-62521783fd15,VHFHeart,right cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002078,564.0,33225.9,800
-http://purl.org/ccf/1.5/32214c14-bf21-4bf6-aea9-58ab721128ab,VHFLargeIntestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,4415.0,140721.9,5000
-http://purl.org/ccf/1.5/3425fa0c-c5cb-4493-b6ba-41520334b13e,VHFLargeIntestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1295.0,46838.66,5000
-http://purl.org/ccf/1.5/3425fa0c-c5cb-4493-b6ba-41520334b13e,VHFLargeIntestine,caecum,http://purl.obolibrary.org/obo/UBERON_0001153,300.0,31765.15,5000
-http://purl.org/ccf/1.5/43e195fb-0f50-4b67-bff1-b74f68290fc6,VHFLargeIntestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,630.0,171672.2,5000
-http://purl.org/ccf/1.5/48f6aab3-8d58-4675-806c-3fd7d5b7336f,VHFLargeIntestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1295.0,46838.66,5000
-http://purl.org/ccf/1.5/48f6aab3-8d58-4675-806c-3fd7d5b7336f,VHFLargeIntestine,caecum,http://purl.obolibrary.org/obo/UBERON_0001153,300.0,31765.15,5000
-http://purl.org/ccf/1.5/8b652088-8c73-466d-b59c-3fbb8c01e399,VHFLargeIntestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,260.0,30343.71,5000
-http://purl.org/ccf/1.5/aab5a316-7fbc-4a57-8b3a-3fc1958c5292,VHFLargeIntestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,4415.0,140721.9,5000
-http://purl.org/ccf/1.5/cd304e60-3de4-4dd9-b289-ce1a0efae4d7,VHFLargeIntestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,260.0,30343.71,5000
-http://purl.org/ccf/1.5/db4f3eca-e9f8-4f9c-88a1-795a20dd0f84,VHFLargeIntestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,630.0,171672.2,5000
-http://purl.org/ccf/1.5/26edd761-8b50-453c-9b03-2337806c9e3a,VHFLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,9.99,2673.251,10
-http://purl.org/ccf/1.5/52c4948d-bdc2-4201-a991-61a2c0a565c0,VHFLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,23.951999999999998,2149.598,24
-http://purl.org/ccf/1.5/61d9f366-c050-4c28-995f-32ab920a7ca8,VHFLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,9.216,8149.503,16
-http://purl.org/ccf/1.5/8d126897-60f6-433e-a56b-cbe730475742,VHFLeftKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,16,132321.3,16
-http://purl.org/ccf/1.5/8f99a469-7d51-46dc-919d-2e002eeae868,VHFLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,30,2480.148,30
-http://purl.org/ccf/1.5/bd004aeb-6e60-4d5b-8d40-cfdd55b8b6fe,VHFLeftKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,26.0,132321.3,52
-http://purl.org/ccf/1.5/bd004aeb-6e60-4d5b-8d40-cfdd55b8b6fe,VHFLeftKidney,renal column,http://purl.obolibrary.org/obo/UBERON_0001284,15.235999999999999,72301.89,52
-http://purl.org/ccf/1.5/bd004aeb-6e60-4d5b-8d40-cfdd55b8b6fe,VHFLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,9.203999999999999,8149.503,52
-http://purl.org/ccf/1.5/fd380a0c-2915-4d73-b3f4-d161badbaccb,VHFLeftKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,24.696,132321.3,72
-http://purl.org/ccf/1.5/fd380a0c-2915-4d73-b3f4-d161badbaccb,VHFLeftKidney,renal column,http://purl.obolibrary.org/obo/UBERON_0001284,0.432,72301.89,72
-http://purl.org/ccf/1.5/fd380a0c-2915-4d73-b3f4-d161badbaccb,VHFLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,43.704,2896.476,72
-http://purl.org/ccf/1.5/5764d42e-95e4-4e5a-b36e-ca498354906d,VHFLeftUreter,left ureter,http://purl.obolibrary.org/obo/UBERON_0001223,8.52,668.666,24
-http://purl.org/ccf/1.5/c5e652ed-7e40-41de-bfc0-a73f05a0c66a,VHFLeftUreter,left ureter,http://purl.obolibrary.org/obo/UBERON_0001223,4.96,668.666,32
-http://purl.org/ccf/1.5/05310dee-180d-4e59-8c58-b101d12f4c73,VHFLung,Right Superior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7366,588.2624999999999,234868.7,1012.5
-http://purl.org/ccf/1.5/05310dee-180d-4e59-8c58-b101d12f4c73,VHFLung,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,869.7375,161360.7,1012.5
-http://purl.org/ccf/1.5/09b9e49f-dd9c-4f9f-a7dc-258ac0d08530,VHFLung,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,245.0,185551.3,1000
-http://purl.org/ccf/1.5/09b9e49f-dd9c-4f9f-a7dc-258ac0d08530,VHFLung,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,737.0,83916.23,1000
-http://purl.org/ccf/1.5/0c1510fa-83b7-43aa-aa70-d261835ce604_LungMap_Female_AllenWangLungMap_FEMALE_tissueblock_RUI,VHFLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,75,149921.4,75
-http://purl.org/ccf/1.5/0c1510fa-83b7-43aa-aa70-d261835ce604_LungMap_Female_AllenWangLungMap_FEMALE_tissueblock_RUI,VHFLung,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,36.225,83916.23,75
-http://purl.org/ccf/1.5/0c1510fa-83b7-43aa-aa70-d261835ce604_LungMap_Female_AllenWangLungMap_FEMALE_tissueblock_RUI,VHFLung,Lateral segmental bronchus,http://purl.org/sig/ont/fma/fma7402,52.275,588.9755,75
-http://purl.org/ccf/1.5/0cd47185-8e8a-4f56-a167-bf93de928553,VHFLung,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,600.0,185551.3,1000
-http://purl.org/ccf/1.5/0cd47185-8e8a-4f56-a167-bf93de928553,VHFLung,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,484.0,83916.23,1000
-http://purl.org/ccf/1.5/2243b679-6c6c-4b66-9479-fef2640f2872,VHFLung,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,1000,374148.9,1000
-http://purl.org/ccf/1.5/25c3d20d-d856-4a22-b926-6ee9a5f4a1d4,VHFLung,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,927.0,185551.3,1000
-http://purl.org/ccf/1.5/25c3d20d-d856-4a22-b926-6ee9a5f4a1d4,VHFLung,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,116.0,83916.23,1000
-http://purl.org/ccf/1.5/3545c186-aafd-4477-adc5-6ee21219cf87,VHFLung,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,1000,374148.9,1000
-http://purl.org/ccf/1.5/3c299376-82f1-4c1f-b283-2c03cb7922e2,VHFLung,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,432.0,185551.3,562.5
-http://purl.org/ccf/1.5/3c299376-82f1-4c1f-b283-2c03cb7922e2,VHFLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,172.6875,149921.4,562.5
-http://purl.org/ccf/1.5/4890aa9b-26a3-4db5-b25a-66e18cbc2158,VHFLung,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,1000,374148.9,1000
-http://purl.org/ccf/1.5/559cb26d-2bed-41a6-8cdf-d5da5f4b52d2,VHFLung,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,1500,161360.7,1500
-http://purl.org/ccf/1.5/8af0476d-e6e6-4b55-afae-5eec8c9c1cb5,VHFLung,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,634.5,185551.3,843.75
-http://purl.org/ccf/1.5/8af0476d-e6e6-4b55-afae-5eec8c9c1cb5,VHFLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,287.71875,149921.4,843.75
-http://purl.org/ccf/1.5/9131c76e-62cb-4433-a216-64e9fa0450c5,VHFLung,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,1000,161360.7,1000
-http://purl.org/ccf/1.5/9131c76e-62cb-4433-a216-64e9fa0450c5,VHFLung,Right Apical Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7338,36.0,151252.1,1000
-http://purl.org/ccf/1.5/965b263e-b1b5-44c3-86ef-bb682091be05,VHFLung,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,500,374148.9,500
-http://purl.org/ccf/1.5/965b263e-b1b5-44c3-86ef-bb682091be05,VHFLung,Right apical segmental bronchus,http://purl.org/sig/ont/fma/fma7398,47.5,2537.346,500
-http://purl.org/ccf/1.5/ab9cafec-3eff-49ac-b2a9-ba96c22d80f9,VHFLung,Left posterior bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7386,980.0,155013.7,1000
-http://purl.org/ccf/1.5/ab9cafec-3eff-49ac-b2a9-ba96c22d80f9,VHFLung,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,1000,113080.3,1000
-http://purl.org/ccf/1.5/c5d8b584-d6b7-4a98-8330-a97ecec688f8,VHFLung,Right Superior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7366,337.5,234868.7,500
-http://purl.org/ccf/1.5/c5d8b584-d6b7-4a98-8330-a97ecec688f8,VHFLung,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,499.0,161360.7,500
-http://purl.org/ccf/1.5/ca4a4754-6937-4d08-9eb0-bf400492c22c,VHFLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,1000,149921.4,1000
-http://purl.org/ccf/1.5/dcbd8b51-3a18-4025-97c1-e1867e346a18,VHFLung,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,1416.0,374148.9,1500
-http://purl.org/ccf/1.5/dcbd8b51-3a18-4025-97c1-e1867e346a18,VHFLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,130.5,149921.4,1500
-http://purl.org/ccf/1.5/dcbd8b51-3a18-4025-97c1-e1867e346a18,VHFLung,Right anterior segmental bronchus,http://purl.org/sig/ont/fma/fma7400,6.0,2374.755,1500
-http://purl.org/ccf/1.5/e7d21a48-63dd-45d8-aedd-e4abed52d5d8,VHFLung,Right Apical Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7338,494.0,151252.1,500
-http://purl.org/ccf/1.5/e7d21a48-63dd-45d8-aedd-e4abed52d5d8,VHFLung,right lung hilus,http://purl.obolibrary.org/obo/UBERON_0004888,5.0,-2918.497,500
-http://purl.org/ccf/1.5/e7d21a48-63dd-45d8-aedd-e4abed52d5d8,VHFLung,right lung hilus,http://purl.obolibrary.org/obo/UBERON_0004888,5.0,-13356.06,500
-http://purl.org/ccf/1.5/f1c3f780-6627-4c56-aada-97cb158f540d,VHFLung,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,901.5,161360.7,1500
-http://purl.org/ccf/1.5/f1c3f780-6627-4c56-aada-97cb158f540d,VHFLung,Right Apical Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7338,1500,151252.1,1500
-http://purl.org/ccf/1.5/f8a20a09-a700-439b-a518-60347cd7b156,VHFLung,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,431.0,185551.3,1000
-http://purl.org/ccf/1.5/f8a20a09-a700-439b-a518-60347cd7b156,VHFLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,602.0,149921.4,1000
-http://purl.org/ccf/1.5/f8a20a09-a700-439b-a518-60347cd7b156,VHFLung,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,237.0,83916.23,1000
-http://purl.org/ccf/1.5/1d965182-bf13-4738-af05-72b817121959,VHFRightKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,1.95,84566.48,50
-http://purl.org/ccf/1.5/1d965182-bf13-4738-af05-72b817121959,VHFRightKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,49.35,3490.235,50
-http://purl.org/ccf/1.5/2a9e525a-4ad9-4085-bca9-31a2d0512008,VHFRightKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,29.43,84566.48,30
-http://purl.org/ccf/1.5/4ae53bc8-b6da-4ba9-9030-a93ae44389b9,VHFRightKidney,renal column,http://purl.obolibrary.org/obo/UBERON_0001284,18,52318.49,18
-http://purl.org/ccf/1.5/4e2e6f98-ec16-4627-a06a-d3cdc282ee1c,VHFRightKidney,renal column,http://purl.obolibrary.org/obo/UBERON_0001284,6.468,52318.49,12
-http://purl.org/ccf/1.5/64c5c92d-dc07-40c4-a702-cbef17753fa6,VHFRightKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,11.532,84566.48,12
-http://purl.org/ccf/1.5/64c5c92d-dc07-40c4-a702-cbef17753fa6,VHFRightKidney,kidney capsule,http://purl.obolibrary.org/obo/UBERON_0002015,0.372,10055.26,12
-http://purl.org/ccf/1.5/6f74a57b-41ce-4581-a206-2e84b58c1c98,VHFRightKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,54.053999999999995,1702.389,78
-http://purl.org/ccf/1.5/85ad9566-c363-4b61-a522-6576b253d9af,VHFRightKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,30,2260.912,30
-http://purl.org/ccf/1.5/f66f91f9-c6c5-414d-b784-2faec33e0505,VHFRightKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,119.88,3490.235,120
-http://purl.org/ccf/1.5/3b5d2036-3c56-4cf8-808f-462c9e3681e5,VHFRightMammaryGland,Interlobar adipose tissue of right mammary gland,http://purl.org/sig/ont/fma/fma73165,384.8,726890.7,400
-http://purl.org/ccf/1.5/6f04ffad-3b9d-4c1c-afc0-fd203b02e5a3,VHFSkin,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,1000,1833227.0,1000
-http://purl.org/ccf/1.5/9e77a7b5-e7e8-48e1-a30e-01eeaa300ed8,VHFSkin,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,2730,1833227.0,2730
-http://purl.org/ccf/1.5/eb92e0e2-838b-4689-b13c-07c3ce31eaf0,VHFSkin,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,357.742,1833227.0,3542
-http://purl.org/ccf/1.5/ee7b09db-e6f5-4114-a8f8-5a19bb3a07c2,VHFSkin,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,734.4000000000001,1833227.0,1836
-http://purl.org/ccf/1.5/4af4b1bd-c71d-4ade-a9f6-47b2ccc9f5bb,VHFSmallIntestine,ileum,http://purl.obolibrary.org/obo/UBERON_0002116,8.1,48943.48,1350
-http://purl.org/ccf/1.5/4af4b1bd-c71d-4ade-a9f6-47b2ccc9f5bb,VHFSmallIntestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,360.45000000000005,4170.36,1350
-http://purl.org/ccf/1.5/5fa952b1-a5a7-4089-bdc2-7208f71f45be,VHFSmallIntestine,superior part of duodenum,http://purl.org/sig/ont/fma/fma14926,35.1,6614.697,1350
-http://purl.org/ccf/1.5/5fa952b1-a5a7-4089-bdc2-7208f71f45be,VHFSmallIntestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,43.2,4498.966,1350
-http://purl.org/ccf/1.5/74c8746d-be53-493d-9a2a-1edbe24f0d16,VHFSmallIntestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,124.2,4974.074,1350
-http://purl.org/ccf/1.5/74c8746d-be53-493d-9a2a-1edbe24f0d16,VHFSmallIntestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,68.85,2636.943,1350
-http://purl.org/ccf/1.5/9d795171-ba1f-4ae2-9b98-9a285280ebf6,VHFSmallIntestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,124.2,4974.074,1350
-http://purl.org/ccf/1.5/9d795171-ba1f-4ae2-9b98-9a285280ebf6,VHFSmallIntestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,68.85,2636.943,1350
-http://purl.org/ccf/1.5/d1085194-4902-4252-95fd-faf03afd9288,VHFSmallIntestine,superior part of duodenum,http://purl.org/sig/ont/fma/fma14926,35.1,6614.697,1350
-http://purl.org/ccf/1.5/d1085194-4902-4252-95fd-faf03afd9288,VHFSmallIntestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,43.2,4498.966,1350
-http://purl.org/ccf/1.5/d194f593-af76-4ee7-84a6-00f7531d47cf,VHFSmallIntestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,139.04999999999998,32188.43,1350
-http://purl.org/ccf/1.5/d8c8faa2-7e2a-4b74-9531-cd08be659c10,VHFSmallIntestine,ileum,http://purl.obolibrary.org/obo/UBERON_0002116,8.1,48943.48,1350
-http://purl.org/ccf/1.5/d8c8faa2-7e2a-4b74-9531-cd08be659c10,VHFSmallIntestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,360.45000000000005,4170.36,1350
-http://purl.org/ccf/1.5/8d0cbb8e-8afd-4d2b-a1af-8b70b6f2f9b3,VHMAllenBrain,middle temporal gyrus,http://purl.obolibrary.org/obo/UBERON_0002771,96.8,21669.13,100
-http://purl.org/ccf/1.5/118235b7-38a4-4fcf-8834-bad5765f5eeb,VHMHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1417.6,121604.2,1600
-http://purl.org/ccf/1.5/20a0c365-6a97-4224-ae14-16fba10c13f8,VHMHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,3397.6319999999996,121604.2,3584
-http://purl.org/ccf/1.5/3156203b-0238-447d-9aae-c4341f2da943,VHMHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1463.3999999999999,121604.2,1800
-http://purl.org/ccf/1.5/39e72b20-77e5-45a5-bb0e-f374ea5894ad,VHMHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1463.3999999999999,121604.2,1800
-http://purl.org/ccf/1.5/7296fad6-bf8e-49da-8f4a-ef76ee4cfeac,VHMHeart,right cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002078,705.76,27714.92,1760
-http://purl.org/ccf/1.5/760368bf-6b4c-4d92-aa2b-24e17fd947d3,VHMHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,2406.144,121604.2,2496
-http://purl.org/ccf/1.5/87df967f-1311-43ac-a306-04e47d2f4a60,VHMHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1463.3999999999999,121604.2,1800
-http://purl.org/ccf/1.5/886e391d-0151-46d3-8a51-084bf6a06910,VHMHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1417.6,121604.2,1600
-http://purl.org/ccf/1.5/a0ff0780-d666-42fe-8068-a3b41b1c6aa0,VHMHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1417.6,121604.2,1600
-http://purl.org/ccf/1.5/bb9dbc76-88b2-43ad-9401-e1e87424efa5,VHMHeart,left cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002079,4584.0,31346.06,8000
-http://purl.org/ccf/1.5/bb9dbc76-88b2-43ad-9401-e1e87424efa5,VHMHeart,aortic valve,http://purl.obolibrary.org/obo/UBERON_0002137,80.0,3027.46,8000
-http://purl.org/ccf/1.5/ce5f3bd0-f091-49fe-8fe5-67004848078b,VHMHeart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,275.0,73988.45,1000
-http://purl.org/ccf/1.5/da28394d-789a-4fba-842a-f8ba5046b221,VHMHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1417.6,121604.2,1600
-http://purl.org/ccf/1.5/de8bd0bf-7765-44c4-9d22-5ff5c0586816,VHMHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1463.3999999999999,121604.2,1800
-http://purl.org/ccf/1.5/f1790d4b-bbc0-434c-b8ed-f21e8b8be903,VHMHeart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,1348.032,73988.45,1904
-http://purl.org/ccf/1.5/f6512db4-2809-4ffe-864d-ace61789dff6,VHMHeart,right cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002078,321.6,27714.92,800
-http://purl.org/ccf/1.5/fdb0d1f7-94d5-4628-b345-dbe4975966fd,VHMHeart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,838.3499999999999,121604.2,2430
-http://purl.org/ccf/1.5/fdb0d1f7-94d5-4628-b345-dbe4975966fd,VHMHeart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,765.45,73988.45,2430
-http://purl.org/ccf/1.5/fdb0d1f7-94d5-4628-b345-dbe4975966fd,VHMHeart,interventricular septum,http://purl.obolibrary.org/obo/UBERON_0002094,1334.0700000000002,28091.88,2430
-http://purl.org/ccf/1.5/09681d25-f08d-40ff-81cb-a731610aa84d,VHMLargeIntestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,2680.0,364972.6,5000
-http://purl.org/ccf/1.5/23e9d58a-c93f-414b-baf9-3692ea20fd1c,VHMLargeIntestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
-http://purl.org/ccf/1.5/2ae3cef9-6621-46da-b056-da7bfbadc13b,VHMLargeIntestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
-http://purl.org/ccf/1.5/2ae3cef9-6621-46da-b056-da7bfbadc13b,VHMLargeIntestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
-http://purl.org/ccf/1.5/37248725-6ed5-4589-ac5a-9951d1a783e7,VHMLargeIntestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
-http://purl.org/ccf/1.5/3b2cb9ee-2a6f-4fb3-bc1b-dbd192d3163c,VHMLargeIntestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
-http://purl.org/ccf/1.5/3c695f26-b7ed-44ad-8e11-894932defa86,VHMLargeIntestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
-http://purl.org/ccf/1.5/5df04f61-5fcc-4035-92c3-631f772a6ce0,VHMLargeIntestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
-http://purl.org/ccf/1.5/6bbdd96b-5fae-406c-a0a5-8e20e1bd0d8e,VHMLargeIntestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
-http://purl.org/ccf/1.5/76a8931b-1c06-4646-8a17-ac7828b6e879,VHMLargeIntestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
-http://purl.org/ccf/1.5/7f0bfe51-5458-4ef8-8641-c3d9a5fbd538,VHMLargeIntestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,2680.0,364972.6,5000
-http://purl.org/ccf/1.5/82566926-7a8f-43a7-9f6a-ae0c463d7a1d,VHMLargeIntestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,2680.0,364972.6,5000
-http://purl.org/ccf/1.5/82d414d4-59a7-4a61-9d86-278cb73a3ddd,VHMLargeIntestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
-http://purl.org/ccf/1.5/8e8d9121-3a47-4c89-9e63-aec6659075d2,VHMLargeIntestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
-http://purl.org/ccf/1.5/91009a1d-ddea-4489-af88-3e32ca47cde7,VHMLargeIntestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
-http://purl.org/ccf/1.5/9a6cb9d5-afdd-429d-98ba-f157a42c7937,VHMLargeIntestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
-http://purl.org/ccf/1.5/abab52f8-6fd4-4e3f-8f9c-bb9f5f62785f,VHMLargeIntestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
-http://purl.org/ccf/1.5/abab52f8-6fd4-4e3f-8f9c-bb9f5f62785f,VHMLargeIntestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
-http://purl.org/ccf/1.5/ba9d007b-c5c7-4231-80f9-42403a98a6df,VHMLargeIntestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
-http://purl.org/ccf/1.5/bceacee1-bc17-49ba-ab6f-833a9ccde436,VHMLargeIntestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,2680.0,364972.6,5000
-http://purl.org/ccf/1.5/c89a4a3c-52d7-4508-86fb-b7e5610cb1e0,VHMLargeIntestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,2680.0,364972.6,5000
-http://purl.org/ccf/1.5/d3b5feb6-910f-4309-a6a8-42c0477227c9,VHMLargeIntestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
-http://purl.org/ccf/1.5/d3b5feb6-910f-4309-a6a8-42c0477227c9,VHMLargeIntestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
-http://purl.org/ccf/1.5/df58ff32-e4db-41fe-9a25-47dbde90c694,VHMLargeIntestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
-http://purl.org/ccf/1.5/df58ff32-e4db-41fe-9a25-47dbde90c694,VHMLargeIntestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
-http://purl.org/ccf/1.5/dfb35d10-65a1-48f9-94a0-baf36ce8a78b,VHMLargeIntestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
-http://purl.org/ccf/1.5/dfb35d10-65a1-48f9-94a0-baf36ce8a78b,VHMLargeIntestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
-http://purl.org/ccf/1.5/e7d386a6-d4fb-43b2-9737-fdc6f7508d79,VHMLargeIntestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
-http://purl.org/ccf/1.5/e7d386a6-d4fb-43b2-9737-fdc6f7508d79,VHMLargeIntestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
-http://purl.org/ccf/1.5/fb4cec06-b147-4277-a6cf-8aa21e294183,VHMLargeIntestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
-http://purl.org/ccf/1.5/2990ecc8-1854-4794-8f11-1b31c5c94e5f,VHMLeftKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,12,119897.3,12
-http://purl.org/ccf/1.5/29e439fb-cfec-4c2d-a14e-3bc60eb8e255,VHMLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,12,2112.787,12
-http://purl.org/ccf/1.5/29e439fb-cfec-4c2d-a14e-3bc60eb8e255,VHMLeftKidney,renal papilla,http://purl.obolibrary.org/obo/UBERON_0001228,3.4079999999999995,29.41792,12
-http://purl.org/ccf/1.5/5166a7a1-bd21-4aa3-ba20-23453cb4c431,VHMLeftKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,48,119897.3,48
-http://purl.org/ccf/1.5/72ea5aad-4be7-4478-afc0-7736bc0d90e3,VHMLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,8.244,2112.787,12
-http://purl.org/ccf/1.5/72ea5aad-4be7-4478-afc0-7736bc0d90e3,VHMLeftKidney,renal papilla,http://purl.obolibrary.org/obo/UBERON_0001228,11.040000000000001,29.41792,12
-http://purl.org/ccf/1.5/7f7fe1b0-d9f6-48c2-a304-2ea5874c7392,VHMLeftKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,1.2,119897.3,30
-http://purl.org/ccf/1.5/7f7fe1b0-d9f6-48c2-a304-2ea5874c7392,VHMLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,30,6220.839,30
-http://purl.org/ccf/1.5/c07ec91d-9dbe-4132-a93c-b960895b009d,VHMLeftKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,22.040000000000003,119897.3,40
-http://purl.org/ccf/1.5/c07ec91d-9dbe-4132-a93c-b960895b009d,VHMLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,21.880000000000003,6220.839,40
-http://purl.org/ccf/1.5/cf4ba102-edf7-4fe4-bb1d-860cdf57609d,VHMLeftKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,9.2,119897.3,100
-http://purl.org/ccf/1.5/cf4ba102-edf7-4fe4-bb1d-860cdf57609d,VHMLeftKidney,renal column,http://purl.obolibrary.org/obo/UBERON_0001284,85.2,39325.43,100
-http://purl.org/ccf/1.5/cf4ba102-edf7-4fe4-bb1d-860cdf57609d,VHMLeftKidney,hilum of kidney,http://purl.obolibrary.org/obo/UBERON_0008716,66.10000000000001,7937.076,100
-http://purl.org/ccf/1.5/cf4ba102-edf7-4fe4-bb1d-860cdf57609d,VHMLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,14.299999999999999,3093.173,100
-http://purl.org/ccf/1.5/f31c1726-c693-4734-8c1c-4f1d64bbe034,VHMLeftKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,40.5,119897.3,60
-http://purl.org/ccf/1.5/f31c1726-c693-4734-8c1c-4f1d64bbe034,VHMLeftKidney,kidney capsule,http://purl.obolibrary.org/obo/UBERON_0002015,5.159999999999999,6251.962,60
-http://purl.org/ccf/1.5/f3f2fabb-6802-4fd4-920e-1914293db252,VHMLeftKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,40,119897.3,40
-http://purl.org/ccf/1.5/f3f2fabb-6802-4fd4-920e-1914293db252,VHMLeftKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,0.04,6220.839,40
-http://purl.org/ccf/1.5/19fee435-ebad-476c-bc9a-e11d2cee035e,VHMLeftUreter,left ureter,http://purl.obolibrary.org/obo/UBERON_0001223,0.568,1685.8,8
-http://purl.org/ccf/1.5/1f414fc5-cb93-45b7-a1b8-0cd21dfa9f7d,VHMLeftUreter,left ureter,http://purl.obolibrary.org/obo/UBERON_0001223,0.28,1685.8,8
-http://purl.org/ccf/1.5/3a25960a-8e7a-4020-8dfb-8ce6c3423e35,VHMLeftUreter,left ureter,http://purl.obolibrary.org/obo/UBERON_0001223,0.168,1685.8,8
-http://purl.org/ccf/1.5/0364c64a-5b0a-493f-a5ee-3adfc837211c,VHMLung,Left posterior bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7386,1000,240984.7,1000
-http://purl.org/ccf/1.5/0364c64a-5b0a-493f-a5ee-3adfc837211c,VHMLung,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,791.0,174591.4,1000
-http://purl.org/ccf/1.5/0f4be9aa-dfce-414f-9d40-47cb38f5eee8,VHMLung,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,500,309071.6,500
-http://purl.org/ccf/1.5/11fcf508-762d-4f0c-b5c5-dad0cf38f4de,VHMLung,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,500,309071.6,500
-http://purl.org/ccf/1.5/3e6d37df-e4f3-4654-b06d-3a76c2e665ea,VHMLung,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,1003.5000000000001,444225.2,1500
-http://purl.org/ccf/1.5/3e6d37df-e4f3-4654-b06d-3a76c2e665ea,VHMLung,Superior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7374,1500,299217.9,1500
-http://purl.org/ccf/1.5/3e6d37df-e4f3-4654-b06d-3a76c2e665ea,VHMLung,Left anterior segmental bronchus,http://purl.org/sig/ont/fma/fma7428,307.5,4557.781,1500
-http://purl.org/ccf/1.5/527bfb3c-5cea-4131-a73a-72687feb8024,VHMLung,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,996.0,444225.2,1000
-http://purl.org/ccf/1.5/527bfb3c-5cea-4131-a73a-72687feb8024,VHMLung,Left anterior segmental bronchus,http://purl.org/sig/ont/fma/fma7428,26.0,4557.781,1000
-http://purl.org/ccf/1.5/527bfb3c-5cea-4131-a73a-72687feb8024,VHMLung,Left apical segmental bronchus,http://purl.org/sig/ont/fma/fma7426,29.0,1850.033,1000
-http://purl.org/ccf/1.5/56b136e7-40dd-477a-b5b6-9be0bb98374c,VHMLung,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,1000,174591.4,1000
-http://purl.org/ccf/1.5/56b136e7-40dd-477a-b5b6-9be0bb98374c,VHMLung,Left apical segmental bronchus,http://purl.org/sig/ont/fma/fma7426,1.0,1850.033,1000
-http://purl.org/ccf/1.5/594902fb-c4c1-47c3-b98e-3101b93a73e4,VHMLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,295.0,229965.0,500
-http://purl.org/ccf/1.5/594902fb-c4c1-47c3-b98e-3101b93a73e4,VHMLung,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,500,162410.7,500
-http://purl.org/ccf/1.5/5b4b476b-01e1-4d13-95e5-d17770f9ffa9,VHMLung,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,948.0,444225.2,1000
-http://purl.org/ccf/1.5/5b4b476b-01e1-4d13-95e5-d17770f9ffa9,VHMLung,Left posterior bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7386,6.0,240984.7,1000
-http://purl.org/ccf/1.5/5b4b476b-01e1-4d13-95e5-d17770f9ffa9,VHMLung,Left apical segmental bronchus,http://purl.org/sig/ont/fma/fma7426,98.0,1850.033,1000
-http://purl.org/ccf/1.5/616ef33e-ebcc-4ece-b440-ca218440c8b4,VHMLung,Inferior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7375,1750.0,130425.0,2000
-http://purl.org/ccf/1.5/74d8c134-9489-4599-afa7-95bd8cf9fc8a,VHMLung,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,489.5,309071.6,500
-http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,2490.0,444225.2,2500
-http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,Superior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7374,95.0,299217.9,2500
-http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,Left anterior segmental bronchus,http://purl.org/sig/ont/fma/fma7428,732.5,4557.781,2500
-http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,Left apical segmental bronchus,http://purl.org/sig/ont/fma/fma7426,7.5,1850.033,2500
-http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,left lung hilus,http://purl.obolibrary.org/obo/UBERON_0004887,434.99999999999994,-14467.8,2500
-http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,left lung hilus,http://purl.obolibrary.org/obo/UBERON_0004887,434.99999999999994,-31882.55,2500
-http://purl.org/ccf/1.5/840b29a9-5a04-41cc-908d-0c4fa5720366,VHMLung,Left posterior bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7386,1467.0,240984.7,1500
-http://purl.org/ccf/1.5/840b29a9-5a04-41cc-908d-0c4fa5720366,VHMLung,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,1500,174591.4,1500
-http://purl.org/ccf/1.5/853a9e2c-10ba-4491-9d9d-3551c0c5f26d,VHMLung,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,750,444225.2,750
-http://purl.org/ccf/1.5/853a9e2c-10ba-4491-9d9d-3551c0c5f26d,VHMLung,Superior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7374,728.25,299217.9,750
-http://purl.org/ccf/1.5/8c2283cd-667a-4fa1-9026-50e30bcfdcd1,VHMLung,Superior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7374,1000,299217.9,1000
-http://purl.org/ccf/1.5/8c2283cd-667a-4fa1-9026-50e30bcfdcd1,VHMLung,Inferior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7375,81.0,130425.0,1000
-http://purl.org/ccf/1.5/8c2283cd-667a-4fa1-9026-50e30bcfdcd1,VHMLung,Superior lingular bronchus,http://purl.org/sig/ont/fma/fma7430,17.0,254.0222,1000
-http://purl.org/ccf/1.5/8d3e8fa1-185d-479b-83d9-9dfe2ead2d3e,VHMLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,1000,229965.0,1000
-http://purl.org/ccf/1.5/95190b47-b491-448a-8e9b-06d804bf2aa1,VHMLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,500,229965.0,500
-http://purl.org/ccf/1.5/95881dfc-b806-40ca-85fd-0e02d647c999,VHMLung,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,190.0,353229.4,500
-http://purl.org/ccf/1.5/95881dfc-b806-40ca-85fd-0e02d647c999,VHMLung,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,483.5,309071.6,500
-http://purl.org/ccf/1.5/95881dfc-b806-40ca-85fd-0e02d647c999,VHMLung,Right superior segmental bronchus,http://purl.org/sig/ont/fma/fma7416,14.5,1456.964,500
-http://purl.org/ccf/1.5/ab2e49b2-1959-44af-8e83-ac16878f6c12,VHMLung,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,1000,174591.4,1000
-http://purl.org/ccf/1.5/aba1ebe3-af18-40cc-b536-b89843049ca5,VHMLung,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,500,162410.7,500
-http://purl.org/ccf/1.5/bb8f70e2-273f-4902-a2ce-70a110aee2ec_AllenWangLungMap_MALE_tissueblock_RUI,VHMLung,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,75,162410.7,75
-http://purl.org/ccf/1.5/bb8f70e2-273f-4902-a2ce-70a110aee2ec_AllenWangLungMap_MALE_tissueblock_RUI,VHMLung,Lateral segmental bronchus,http://purl.org/sig/ont/fma/fma7402,13.65,665.072,75
-http://purl.org/ccf/1.5/c8cdaa06-847b-4747-9a00-d89761cea031,VHMLung,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,1000,174591.4,1000
-http://purl.org/ccf/1.5/cfa23a23-1cef-4a6f-8303-d1198e91a773,VHMLung,Left posterior bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7386,1000,240984.7,1000
-http://purl.org/ccf/1.5/d51b9d67-837f-4451-a6c6-0b63c7879736,VHMLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,500,229965.0,500
-http://purl.org/ccf/1.5/d662fd53-e925-4921-8d8b-bc91eed1519b,VHMLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,746.25,229965.0,750
-http://purl.org/ccf/1.5/f15f5400-2ef9-45fc-bf0f-72f14d6f8f9e,VHMLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,750,229965.0,750
-http://purl.org/ccf/1.5/f4a116d7-f844-4d4a-bc8f-632151125313,VHMLung,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,1000,444225.2,1000
-http://purl.org/ccf/1.5/fd4fcec2-93c3-428f-ad3a-6c7ac4196da0,VHMLung,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,125.0,229965.0,500
-http://purl.org/ccf/1.5/fd4fcec2-93c3-428f-ad3a-6c7ac4196da0,VHMLung,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,500,162410.7,500
-http://purl.org/ccf/1.5/5475ae38-db50-4868-92ba-8718bf136c7b,VHMProstate,peripheral zone of prostate,http://purl.obolibrary.org/obo/UBERON_8410026,319.2,4502.339,700
-http://purl.org/ccf/1.5/5475ae38-db50-4868-92ba-8718bf136c7b,VHMProstate,peripheral zone of prostate,http://purl.obolibrary.org/obo/UBERON_8410026,320.6,4398.495,700
-http://purl.org/ccf/1.5/5475ae38-db50-4868-92ba-8718bf136c7b,VHMProstate,central zone of prostate,http://purl.obolibrary.org/obo/UBERON_8410027,33.6,1846.38,700
-http://purl.org/ccf/1.5/5475ae38-db50-4868-92ba-8718bf136c7b,VHMProstate,central zone of prostate,http://purl.obolibrary.org/obo/UBERON_8410027,30.099999999999998,1753.812,700
-http://purl.org/ccf/1.5/57bab703-98bd-4106-9160-af951a74e4df,VHMRightKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,11.328,1911.797,12
-http://purl.org/ccf/1.5/57bab703-98bd-4106-9160-af951a74e4df,VHMRightKidney,renal papilla,http://purl.obolibrary.org/obo/UBERON_0001228,5.712,32.27643,12
-http://purl.org/ccf/1.5/69ac0df4-f442-4d62-90dc-86fcbc38eb23,VHMRightKidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,40,4454.755,40
-http://purl.org/ccf/1.5/6a6392a9-8ac1-4666-a684-83d310ca055f,VHMRightKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,120,109925.0,120
-http://purl.org/ccf/1.5/769ca7e9-ead0-4882-966c-d6f5c273c2ee,VHMRightKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,180,109925.0,180
-http://purl.org/ccf/1.5/db35f27d-313f-4dd6-819b-375cf106aac1,VHMRightKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,12,109925.0,12
-http://purl.org/ccf/1.5/df0b33f7-371a-47a4-a636-a27db19bdbc9,VHMRightKidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,48,109925.0,48
-http://purl.org/ccf/1.5/314450f7-0477-4152-b4d6-cb474cbc0cd7,VHMSkin,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,644.436,2109804.0,7956
-http://purl.org/ccf/1.5/56d63930-60f2-49f5-a3bb-afc8d865c152,VHMSkin,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,2352,2109804.0,2352
-http://purl.org/ccf/1.5/cce37703-e4e8-454c-a0c4-4ff58652ab8f,VHMSkin,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,1000,2109804.0,1000
-http://purl.org/ccf/1.5/d16014ad-8b92-487b-bca7-044d3d745dba,VHMSkin,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,1397.088,2109804.0,2156
-http://purl.org/ccf/1.5/fcfcc65b-f91f-4447-a29b-c9836104570c,VHMSkin,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,1008,2109804.0,1008
-http://purl.org/ccf/1.5/ff034c0c-a625-48b8-891c-857e556db1c4,VHMSkin,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,1386,2109804.0,1386
-http://purl.org/ccf/1.5/1f53fe4d-d77b-4508-ba36-22b6b3ac0e53,VHMSmallIntestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
-http://purl.org/ccf/1.5/27c90961-5430-4217-ad97-4feaa91cede7,VHMSmallIntestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
-http://purl.org/ccf/1.5/2b38ef86-7e4d-4e27-b9c6-d2015ec49692,VHMSmallIntestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
-http://purl.org/ccf/1.5/3177d8d7-3b26-4aa3-9984-3c112d461446,VHMSmallIntestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
-http://purl.org/ccf/1.5/3177d8d7-3b26-4aa3-9984-3c112d461446,VHMSmallIntestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
-http://purl.org/ccf/1.5/42b97dcb-2033-40ea-82a2-319a1e30dca2,VHMSmallIntestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
-http://purl.org/ccf/1.5/42b97dcb-2033-40ea-82a2-319a1e30dca2,VHMSmallIntestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
-http://purl.org/ccf/1.5/470a6b74-a31b-4a50-bfff-da1b475c945b,VHMSmallIntestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
-http://purl.org/ccf/1.5/502f175c-9d55-4341-b6ff-0f04d76522d5,VHMSmallIntestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350
-http://purl.org/ccf/1.5/5d35eae0-82df-40c7-952c-6fbab03034b2,VHMSmallIntestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
-http://purl.org/ccf/1.5/63b2f5a9-5914-4c45-9239-139948a93498,VHMSmallIntestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
-http://purl.org/ccf/1.5/6f055461-adb2-41fe-86c1-50d3afdf9360,VHMSmallIntestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
-http://purl.org/ccf/1.5/6f89860a-30df-4b79-8e6d-dd209c959374,VHMSmallIntestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
-http://purl.org/ccf/1.5/6fe91946-48bb-485f-9ad0-5f0550d1f2b3,VHMSmallIntestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
-http://purl.org/ccf/1.5/75ff443d-c177-4dab-a866-89e9141b73a4,VHMSmallIntestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
-http://purl.org/ccf/1.5/75ff443d-c177-4dab-a866-89e9141b73a4,VHMSmallIntestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
-http://purl.org/ccf/1.5/78ee24bb-4ae4-49e9-bad2-d6f13166b89e,VHMSmallIntestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
-http://purl.org/ccf/1.5/78ee24bb-4ae4-49e9-bad2-d6f13166b89e,VHMSmallIntestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
-http://purl.org/ccf/1.5/79a10f00-84e0-4b8e-8622-485973df3773,VHMSmallIntestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350
-http://purl.org/ccf/1.5/8023d0ab-338a-43c4-9f9b-d637220f1b8e,VHMSmallIntestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350
-http://purl.org/ccf/1.5/85765dd5-2197-4361-b4c6-c9d30186044a,VHMSmallIntestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
-http://purl.org/ccf/1.5/a1fc9d45-5af9-4fc4-b2be-340ef0716e09,VHMSmallIntestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
-http://purl.org/ccf/1.5/a1fc9d45-5af9-4fc4-b2be-340ef0716e09,VHMSmallIntestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
-http://purl.org/ccf/1.5/b09f5826-e6fa-4bec-8054-2fb6e6f202ae,VHMSmallIntestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
-http://purl.org/ccf/1.5/bddd9066-3f8c-4330-8e33-23be89ee8a0b,VHMSmallIntestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350
-http://purl.org/ccf/1.5/d9aed544-4c6e-42c2-a137-9a9381d8f8c8,VHMSmallIntestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
-http://purl.org/ccf/1.5/d9aed544-4c6e-42c2-a137-9a9381d8f8c8,VHMSmallIntestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
-http://purl.org/ccf/1.5/e4a44b76-53fd-4c88-9ccf-ba095fcb9673,VHMSmallIntestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
-http://purl.org/ccf/1.5/ea1d468d-e988-42cd-8e34-71701e568878,VHMSmallIntestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350
-http://purl.org/ccf/1.5/fd76b9bb-85b0-4dd0-8e60-7c6ec7c95d73,VHMSmallIntestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350
+rui_location,organ,organ_label,as_label,as_id,intersection_volume,as_volume,tissue_block_volume
+http://purl.org/ccf/1.5/bf67cdbe-2af0-478e-af80-14e593bdbde1,VHFAllenBrain,brain,middle temporal gyrus,http://purl.obolibrary.org/obo/UBERON_0002771,95.39999999999999,21669.14,100
+http://purl.org/ccf/1.5/04baf323-eda0-4f72-bea1-aa943aa70894,VHFHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,3862.528,229312.8,4096
+http://purl.org/ccf/1.5/05c11830-1526-4472-bd12-ea24dbcfd3cc,VHFHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,3549.1499999999996,229312.8,7425
+http://purl.org/ccf/1.5/05c11830-1526-4472-bd12-ea24dbcfd3cc,VHFHeart,heart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,883.5749999999999,78714.76,7425
+http://purl.org/ccf/1.5/05c11830-1526-4472-bd12-ea24dbcfd3cc,VHFHeart,heart,interventricular septum,http://purl.obolibrary.org/obo/UBERON_0002094,5531.625,65894.53,7425
+http://purl.org/ccf/1.5/05c11830-1526-4472-bd12-ea24dbcfd3cc,VHFHeart,heart,Posteromedial head of posterior papillary muscle of left ventricle,http://purl.org/sig/ont/fma/fma7267,631.125,4401.499,7425
+http://purl.org/ccf/1.5/16e98d8c-8983-48c2-bb41-7b1cfbbf2e4a,VHFHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,2670.122,229312.8,3094
+http://purl.org/ccf/1.5/1995aefd-5289-4652-a7e0-cc66c495649f,VHFHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1491.7630000000001,229312.8,2197
+http://purl.org/ccf/1.5/1995aefd-5289-4652-a7e0-cc66c495649f,VHFHeart,heart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,347.126,78714.76,2197
+http://purl.org/ccf/1.5/1995aefd-5289-4652-a7e0-cc66c495649f,VHFHeart,heart,interventricular septum,http://purl.obolibrary.org/obo/UBERON_0002094,127.426,65894.53,2197
+http://purl.org/ccf/1.5/1fe61622-ba53-47c9-967e-e764c21b8189,VHFHeart,heart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,2023.1999999999998,78714.76,2400
+http://purl.org/ccf/1.5/2156f837-2ab2-4305-8e7f-8084249e91cd,VHFHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,2687.1600000000003,229312.8,2940
+http://purl.org/ccf/1.5/2816c343-c908-45bf-8964-974b1c54a5b9,VHFHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,3862.528,229312.8,4096
+http://purl.org/ccf/1.5/53b083ab-cb70-4096-b385-85590ddc370c,VHFHeart,heart,left cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002079,553.3919999999999,18115.97,4536
+http://purl.org/ccf/1.5/53b083ab-cb70-4096-b385-85590ddc370c,VHFHeart,heart,aortic valve,http://purl.obolibrary.org/obo/UBERON_0002137,22.68,3612.979,4536
+http://purl.org/ccf/1.5/9abfed4e-2fde-4d80-a8aa-7439a106d895,VHFHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,6972.4800000000005,229312.8,8640
+http://purl.org/ccf/1.5/9f2c1d5d-2ad4-4a7a-ad95-622c7328b554,VHFHeart,heart,right cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002078,2096.64,33225.9,4368
+http://purl.org/ccf/1.5/a04e60c6-693a-4c25-a069-62521783fd15,VHFHeart,heart,right cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002078,564.0,33225.9,800
+http://purl.org/ccf/1.5/32214c14-bf21-4bf6-aea9-58ab721128ab,VHFLargeIntestine,large intestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,4415.0,140721.9,5000
+http://purl.org/ccf/1.5/3425fa0c-c5cb-4493-b6ba-41520334b13e,VHFLargeIntestine,large intestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1295.0,46838.66,5000
+http://purl.org/ccf/1.5/3425fa0c-c5cb-4493-b6ba-41520334b13e,VHFLargeIntestine,large intestine,caecum,http://purl.obolibrary.org/obo/UBERON_0001153,300.0,31765.15,5000
+http://purl.org/ccf/1.5/43e195fb-0f50-4b67-bff1-b74f68290fc6,VHFLargeIntestine,large intestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,630.0,171672.2,5000
+http://purl.org/ccf/1.5/48f6aab3-8d58-4675-806c-3fd7d5b7336f,VHFLargeIntestine,large intestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1295.0,46838.66,5000
+http://purl.org/ccf/1.5/48f6aab3-8d58-4675-806c-3fd7d5b7336f,VHFLargeIntestine,large intestine,caecum,http://purl.obolibrary.org/obo/UBERON_0001153,300.0,31765.15,5000
+http://purl.org/ccf/1.5/8b652088-8c73-466d-b59c-3fbb8c01e399,VHFLargeIntestine,large intestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,260.0,30343.71,5000
+http://purl.org/ccf/1.5/aab5a316-7fbc-4a57-8b3a-3fc1958c5292,VHFLargeIntestine,large intestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,4415.0,140721.9,5000
+http://purl.org/ccf/1.5/cd304e60-3de4-4dd9-b289-ce1a0efae4d7,VHFLargeIntestine,large intestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,260.0,30343.71,5000
+http://purl.org/ccf/1.5/db4f3eca-e9f8-4f9c-88a1-795a20dd0f84,VHFLargeIntestine,large intestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,630.0,171672.2,5000
+http://purl.org/ccf/1.5/26edd761-8b50-453c-9b03-2337806c9e3a,VHFLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,9.99,2673.251,10
+http://purl.org/ccf/1.5/52c4948d-bdc2-4201-a991-61a2c0a565c0,VHFLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,23.951999999999998,2149.598,24
+http://purl.org/ccf/1.5/61d9f366-c050-4c28-995f-32ab920a7ca8,VHFLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,9.216,8149.503,16
+http://purl.org/ccf/1.5/8d126897-60f6-433e-a56b-cbe730475742,VHFLeftKidney,left kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,16,132321.3,16
+http://purl.org/ccf/1.5/8f99a469-7d51-46dc-919d-2e002eeae868,VHFLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,30,2480.148,30
+http://purl.org/ccf/1.5/bd004aeb-6e60-4d5b-8d40-cfdd55b8b6fe,VHFLeftKidney,left kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,26.0,132321.3,52
+http://purl.org/ccf/1.5/bd004aeb-6e60-4d5b-8d40-cfdd55b8b6fe,VHFLeftKidney,left kidney,renal column,http://purl.obolibrary.org/obo/UBERON_0001284,15.235999999999999,72301.89,52
+http://purl.org/ccf/1.5/bd004aeb-6e60-4d5b-8d40-cfdd55b8b6fe,VHFLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,9.203999999999999,8149.503,52
+http://purl.org/ccf/1.5/fd380a0c-2915-4d73-b3f4-d161badbaccb,VHFLeftKidney,left kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,24.696,132321.3,72
+http://purl.org/ccf/1.5/fd380a0c-2915-4d73-b3f4-d161badbaccb,VHFLeftKidney,left kidney,renal column,http://purl.obolibrary.org/obo/UBERON_0001284,0.432,72301.89,72
+http://purl.org/ccf/1.5/fd380a0c-2915-4d73-b3f4-d161badbaccb,VHFLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,43.704,2896.476,72
+http://purl.org/ccf/1.5/5764d42e-95e4-4e5a-b36e-ca498354906d,VHFLeftUreter,left ureter,left ureter,http://purl.obolibrary.org/obo/UBERON_0001223,8.52,668.666,24
+http://purl.org/ccf/1.5/c5e652ed-7e40-41de-bfc0-a73f05a0c66a,VHFLeftUreter,left ureter,left ureter,http://purl.obolibrary.org/obo/UBERON_0001223,4.96,668.666,32
+http://purl.org/ccf/1.5/05310dee-180d-4e59-8c58-b101d12f4c73,VHFLung,respiratory system,Right Superior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7366,588.2624999999999,234868.7,1012.5
+http://purl.org/ccf/1.5/05310dee-180d-4e59-8c58-b101d12f4c73,VHFLung,respiratory system,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,869.7375,161360.7,1012.5
+http://purl.org/ccf/1.5/09b9e49f-dd9c-4f9f-a7dc-258ac0d08530,VHFLung,respiratory system,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,245.0,185551.3,1000
+http://purl.org/ccf/1.5/09b9e49f-dd9c-4f9f-a7dc-258ac0d08530,VHFLung,respiratory system,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,737.0,83916.23,1000
+http://purl.org/ccf/1.5/0c1510fa-83b7-43aa-aa70-d261835ce604_LungMap_Female_AllenWangLungMap_FEMALE_tissueblock_RUI,VHFLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,75,149921.4,75
+http://purl.org/ccf/1.5/0c1510fa-83b7-43aa-aa70-d261835ce604_LungMap_Female_AllenWangLungMap_FEMALE_tissueblock_RUI,VHFLung,respiratory system,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,36.225,83916.23,75
+http://purl.org/ccf/1.5/0c1510fa-83b7-43aa-aa70-d261835ce604_LungMap_Female_AllenWangLungMap_FEMALE_tissueblock_RUI,VHFLung,respiratory system,Lateral segmental bronchus,http://purl.org/sig/ont/fma/fma7402,52.275,588.9755,75
+http://purl.org/ccf/1.5/0cd47185-8e8a-4f56-a167-bf93de928553,VHFLung,respiratory system,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,600.0,185551.3,1000
+http://purl.org/ccf/1.5/0cd47185-8e8a-4f56-a167-bf93de928553,VHFLung,respiratory system,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,484.0,83916.23,1000
+http://purl.org/ccf/1.5/2243b679-6c6c-4b66-9479-fef2640f2872,VHFLung,respiratory system,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,1000,374148.9,1000
+http://purl.org/ccf/1.5/25c3d20d-d856-4a22-b926-6ee9a5f4a1d4,VHFLung,respiratory system,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,927.0,185551.3,1000
+http://purl.org/ccf/1.5/25c3d20d-d856-4a22-b926-6ee9a5f4a1d4,VHFLung,respiratory system,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,116.0,83916.23,1000
+http://purl.org/ccf/1.5/3545c186-aafd-4477-adc5-6ee21219cf87,VHFLung,respiratory system,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,1000,374148.9,1000
+http://purl.org/ccf/1.5/3c299376-82f1-4c1f-b283-2c03cb7922e2,VHFLung,respiratory system,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,432.0,185551.3,562.5
+http://purl.org/ccf/1.5/3c299376-82f1-4c1f-b283-2c03cb7922e2,VHFLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,172.6875,149921.4,562.5
+http://purl.org/ccf/1.5/4890aa9b-26a3-4db5-b25a-66e18cbc2158,VHFLung,respiratory system,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,1000,374148.9,1000
+http://purl.org/ccf/1.5/559cb26d-2bed-41a6-8cdf-d5da5f4b52d2,VHFLung,respiratory system,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,1500,161360.7,1500
+http://purl.org/ccf/1.5/8af0476d-e6e6-4b55-afae-5eec8c9c1cb5,VHFLung,respiratory system,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,634.5,185551.3,843.75
+http://purl.org/ccf/1.5/8af0476d-e6e6-4b55-afae-5eec8c9c1cb5,VHFLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,287.71875,149921.4,843.75
+http://purl.org/ccf/1.5/9131c76e-62cb-4433-a216-64e9fa0450c5,VHFLung,respiratory system,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,1000,161360.7,1000
+http://purl.org/ccf/1.5/9131c76e-62cb-4433-a216-64e9fa0450c5,VHFLung,respiratory system,Right Apical Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7338,36.0,151252.1,1000
+http://purl.org/ccf/1.5/965b263e-b1b5-44c3-86ef-bb682091be05,VHFLung,respiratory system,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,500,374148.9,500
+http://purl.org/ccf/1.5/965b263e-b1b5-44c3-86ef-bb682091be05,VHFLung,respiratory system,Right apical segmental bronchus,http://purl.org/sig/ont/fma/fma7398,47.5,2537.346,500
+http://purl.org/ccf/1.5/ab9cafec-3eff-49ac-b2a9-ba96c22d80f9,VHFLung,respiratory system,Left posterior bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7386,980.0,155013.7,1000
+http://purl.org/ccf/1.5/ab9cafec-3eff-49ac-b2a9-ba96c22d80f9,VHFLung,respiratory system,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,1000,113080.3,1000
+http://purl.org/ccf/1.5/c5d8b584-d6b7-4a98-8330-a97ecec688f8,VHFLung,respiratory system,Right Superior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7366,337.5,234868.7,500
+http://purl.org/ccf/1.5/c5d8b584-d6b7-4a98-8330-a97ecec688f8,VHFLung,respiratory system,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,499.0,161360.7,500
+http://purl.org/ccf/1.5/ca4a4754-6937-4d08-9eb0-bf400492c22c,VHFLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,1000,149921.4,1000
+http://purl.org/ccf/1.5/dcbd8b51-3a18-4025-97c1-e1867e346a18,VHFLung,respiratory system,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,1416.0,374148.9,1500
+http://purl.org/ccf/1.5/dcbd8b51-3a18-4025-97c1-e1867e346a18,VHFLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,130.5,149921.4,1500
+http://purl.org/ccf/1.5/dcbd8b51-3a18-4025-97c1-e1867e346a18,VHFLung,respiratory system,Right anterior segmental bronchus,http://purl.org/sig/ont/fma/fma7400,6.0,2374.755,1500
+http://purl.org/ccf/1.5/e7d21a48-63dd-45d8-aedd-e4abed52d5d8,VHFLung,respiratory system,Right Apical Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7338,494.0,151252.1,500
+http://purl.org/ccf/1.5/e7d21a48-63dd-45d8-aedd-e4abed52d5d8,VHFLung,respiratory system,right lung hilus,http://purl.obolibrary.org/obo/UBERON_0004888,5.0,-2918.497,500
+http://purl.org/ccf/1.5/e7d21a48-63dd-45d8-aedd-e4abed52d5d8,VHFLung,respiratory system,right lung hilus,http://purl.obolibrary.org/obo/UBERON_0004888,5.0,-13356.06,500
+http://purl.org/ccf/1.5/f1c3f780-6627-4c56-aada-97cb158f540d,VHFLung,respiratory system,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,901.5,161360.7,1500
+http://purl.org/ccf/1.5/f1c3f780-6627-4c56-aada-97cb158f540d,VHFLung,respiratory system,Right Apical Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7338,1500,151252.1,1500
+http://purl.org/ccf/1.5/f8a20a09-a700-439b-a518-60347cd7b156,VHFLung,respiratory system,Right anterior basal bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7364,431.0,185551.3,1000
+http://purl.org/ccf/1.5/f8a20a09-a700-439b-a518-60347cd7b156,VHFLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,602.0,149921.4,1000
+http://purl.org/ccf/1.5/f8a20a09-a700-439b-a518-60347cd7b156,VHFLung,respiratory system,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,237.0,83916.23,1000
+http://purl.org/ccf/1.5/1d965182-bf13-4738-af05-72b817121959,VHFRightKidney,right kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,1.95,84566.48,50
+http://purl.org/ccf/1.5/1d965182-bf13-4738-af05-72b817121959,VHFRightKidney,right kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,49.35,3490.235,50
+http://purl.org/ccf/1.5/2a9e525a-4ad9-4085-bca9-31a2d0512008,VHFRightKidney,right kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,29.43,84566.48,30
+http://purl.org/ccf/1.5/4ae53bc8-b6da-4ba9-9030-a93ae44389b9,VHFRightKidney,right kidney,renal column,http://purl.obolibrary.org/obo/UBERON_0001284,18,52318.49,18
+http://purl.org/ccf/1.5/4e2e6f98-ec16-4627-a06a-d3cdc282ee1c,VHFRightKidney,right kidney,renal column,http://purl.obolibrary.org/obo/UBERON_0001284,6.468,52318.49,12
+http://purl.org/ccf/1.5/64c5c92d-dc07-40c4-a702-cbef17753fa6,VHFRightKidney,right kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,11.532,84566.48,12
+http://purl.org/ccf/1.5/64c5c92d-dc07-40c4-a702-cbef17753fa6,VHFRightKidney,right kidney,kidney capsule,http://purl.obolibrary.org/obo/UBERON_0002015,0.372,10055.26,12
+http://purl.org/ccf/1.5/6f74a57b-41ce-4581-a206-2e84b58c1c98,VHFRightKidney,right kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,54.053999999999995,1702.389,78
+http://purl.org/ccf/1.5/85ad9566-c363-4b61-a522-6576b253d9af,VHFRightKidney,right kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,30,2260.912,30
+http://purl.org/ccf/1.5/f66f91f9-c6c5-414d-b784-2faec33e0505,VHFRightKidney,right kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,119.88,3490.235,120
+http://purl.org/ccf/1.5/3b5d2036-3c56-4cf8-808f-462c9e3681e5,VHFRightMammaryGland,Set of lactiferous glands in right breast,Interlobar adipose tissue of right mammary gland,http://purl.org/sig/ont/fma/fma73165,384.8,726890.7,400
+http://purl.org/ccf/1.5/6f04ffad-3b9d-4c1c-afc0-fd203b02e5a3,VHFSkin,skin of body,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,1000,1833227.0,1000
+http://purl.org/ccf/1.5/9e77a7b5-e7e8-48e1-a30e-01eeaa300ed8,VHFSkin,skin of body,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,2730,1833227.0,2730
+http://purl.org/ccf/1.5/eb92e0e2-838b-4689-b13c-07c3ce31eaf0,VHFSkin,skin of body,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,357.742,1833227.0,3542
+http://purl.org/ccf/1.5/ee7b09db-e6f5-4114-a8f8-5a19bb3a07c2,VHFSkin,skin of body,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,734.4000000000001,1833227.0,1836
+http://purl.org/ccf/1.5/4af4b1bd-c71d-4ade-a9f6-47b2ccc9f5bb,VHFSmallIntestine,small intestine,ileum,http://purl.obolibrary.org/obo/UBERON_0002116,8.1,48943.48,1350
+http://purl.org/ccf/1.5/4af4b1bd-c71d-4ade-a9f6-47b2ccc9f5bb,VHFSmallIntestine,small intestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,360.45000000000005,4170.36,1350
+http://purl.org/ccf/1.5/5fa952b1-a5a7-4089-bdc2-7208f71f45be,VHFSmallIntestine,small intestine,superior part of duodenum,http://purl.org/sig/ont/fma/fma14926,35.1,6614.697,1350
+http://purl.org/ccf/1.5/5fa952b1-a5a7-4089-bdc2-7208f71f45be,VHFSmallIntestine,small intestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,43.2,4498.966,1350
+http://purl.org/ccf/1.5/74c8746d-be53-493d-9a2a-1edbe24f0d16,VHFSmallIntestine,small intestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,124.2,4974.074,1350
+http://purl.org/ccf/1.5/74c8746d-be53-493d-9a2a-1edbe24f0d16,VHFSmallIntestine,small intestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,68.85,2636.943,1350
+http://purl.org/ccf/1.5/9d795171-ba1f-4ae2-9b98-9a285280ebf6,VHFSmallIntestine,small intestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,124.2,4974.074,1350
+http://purl.org/ccf/1.5/9d795171-ba1f-4ae2-9b98-9a285280ebf6,VHFSmallIntestine,small intestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,68.85,2636.943,1350
+http://purl.org/ccf/1.5/d1085194-4902-4252-95fd-faf03afd9288,VHFSmallIntestine,small intestine,superior part of duodenum,http://purl.org/sig/ont/fma/fma14926,35.1,6614.697,1350
+http://purl.org/ccf/1.5/d1085194-4902-4252-95fd-faf03afd9288,VHFSmallIntestine,small intestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,43.2,4498.966,1350
+http://purl.org/ccf/1.5/d194f593-af76-4ee7-84a6-00f7531d47cf,VHFSmallIntestine,small intestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,139.04999999999998,32188.43,1350
+http://purl.org/ccf/1.5/d8c8faa2-7e2a-4b74-9531-cd08be659c10,VHFSmallIntestine,small intestine,ileum,http://purl.obolibrary.org/obo/UBERON_0002116,8.1,48943.48,1350
+http://purl.org/ccf/1.5/d8c8faa2-7e2a-4b74-9531-cd08be659c10,VHFSmallIntestine,small intestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,360.45000000000005,4170.36,1350
+http://purl.org/ccf/1.5/8d0cbb8e-8afd-4d2b-a1af-8b70b6f2f9b3,VHMAllenBrain,brain,middle temporal gyrus,http://purl.obolibrary.org/obo/UBERON_0002771,96.8,21669.13,100
+http://purl.org/ccf/1.5/118235b7-38a4-4fcf-8834-bad5765f5eeb,VHMHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1417.6,121604.2,1600
+http://purl.org/ccf/1.5/20a0c365-6a97-4224-ae14-16fba10c13f8,VHMHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,3397.6319999999996,121604.2,3584
+http://purl.org/ccf/1.5/3156203b-0238-447d-9aae-c4341f2da943,VHMHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1463.3999999999999,121604.2,1800
+http://purl.org/ccf/1.5/39e72b20-77e5-45a5-bb0e-f374ea5894ad,VHMHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1463.3999999999999,121604.2,1800
+http://purl.org/ccf/1.5/7296fad6-bf8e-49da-8f4a-ef76ee4cfeac,VHMHeart,heart,right cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002078,705.76,27714.92,1760
+http://purl.org/ccf/1.5/760368bf-6b4c-4d92-aa2b-24e17fd947d3,VHMHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,2406.144,121604.2,2496
+http://purl.org/ccf/1.5/87df967f-1311-43ac-a306-04e47d2f4a60,VHMHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1463.3999999999999,121604.2,1800
+http://purl.org/ccf/1.5/886e391d-0151-46d3-8a51-084bf6a06910,VHMHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1417.6,121604.2,1600
+http://purl.org/ccf/1.5/a0ff0780-d666-42fe-8068-a3b41b1c6aa0,VHMHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1417.6,121604.2,1600
+http://purl.org/ccf/1.5/bb9dbc76-88b2-43ad-9401-e1e87424efa5,VHMHeart,heart,left cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002079,4584.0,31346.06,8000
+http://purl.org/ccf/1.5/bb9dbc76-88b2-43ad-9401-e1e87424efa5,VHMHeart,heart,aortic valve,http://purl.obolibrary.org/obo/UBERON_0002137,80.0,3027.46,8000
+http://purl.org/ccf/1.5/ce5f3bd0-f091-49fe-8fe5-67004848078b,VHMHeart,heart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,275.0,73988.45,1000
+http://purl.org/ccf/1.5/da28394d-789a-4fba-842a-f8ba5046b221,VHMHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1417.6,121604.2,1600
+http://purl.org/ccf/1.5/de8bd0bf-7765-44c4-9d22-5ff5c0586816,VHMHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,1463.3999999999999,121604.2,1800
+http://purl.org/ccf/1.5/f1790d4b-bbc0-434c-b8ed-f21e8b8be903,VHMHeart,heart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,1348.032,73988.45,1904
+http://purl.org/ccf/1.5/f6512db4-2809-4ffe-864d-ace61789dff6,VHMHeart,heart,right cardiac atrium,http://purl.obolibrary.org/obo/UBERON_0002078,321.6,27714.92,800
+http://purl.org/ccf/1.5/fdb0d1f7-94d5-4628-b345-dbe4975966fd,VHMHeart,heart,heart left ventricle,http://purl.obolibrary.org/obo/UBERON_0002084,838.3499999999999,121604.2,2430
+http://purl.org/ccf/1.5/fdb0d1f7-94d5-4628-b345-dbe4975966fd,VHMHeart,heart,heart right ventricle,http://purl.obolibrary.org/obo/UBERON_0002080,765.45,73988.45,2430
+http://purl.org/ccf/1.5/fdb0d1f7-94d5-4628-b345-dbe4975966fd,VHMHeart,heart,interventricular septum,http://purl.obolibrary.org/obo/UBERON_0002094,1334.0700000000002,28091.88,2430
+http://purl.org/ccf/1.5/09681d25-f08d-40ff-81cb-a731610aa84d,VHMLargeIntestine,large intestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,2680.0,364972.6,5000
+http://purl.org/ccf/1.5/23e9d58a-c93f-414b-baf9-3692ea20fd1c,VHMLargeIntestine,large intestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
+http://purl.org/ccf/1.5/2ae3cef9-6621-46da-b056-da7bfbadc13b,VHMLargeIntestine,large intestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
+http://purl.org/ccf/1.5/2ae3cef9-6621-46da-b056-da7bfbadc13b,VHMLargeIntestine,large intestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
+http://purl.org/ccf/1.5/37248725-6ed5-4589-ac5a-9951d1a783e7,VHMLargeIntestine,large intestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
+http://purl.org/ccf/1.5/3b2cb9ee-2a6f-4fb3-bc1b-dbd192d3163c,VHMLargeIntestine,large intestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
+http://purl.org/ccf/1.5/3c695f26-b7ed-44ad-8e11-894932defa86,VHMLargeIntestine,large intestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
+http://purl.org/ccf/1.5/5df04f61-5fcc-4035-92c3-631f772a6ce0,VHMLargeIntestine,large intestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
+http://purl.org/ccf/1.5/6bbdd96b-5fae-406c-a0a5-8e20e1bd0d8e,VHMLargeIntestine,large intestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
+http://purl.org/ccf/1.5/76a8931b-1c06-4646-8a17-ac7828b6e879,VHMLargeIntestine,large intestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
+http://purl.org/ccf/1.5/7f0bfe51-5458-4ef8-8641-c3d9a5fbd538,VHMLargeIntestine,large intestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,2680.0,364972.6,5000
+http://purl.org/ccf/1.5/82566926-7a8f-43a7-9f6a-ae0c463d7a1d,VHMLargeIntestine,large intestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,2680.0,364972.6,5000
+http://purl.org/ccf/1.5/82d414d4-59a7-4a61-9d86-278cb73a3ddd,VHMLargeIntestine,large intestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
+http://purl.org/ccf/1.5/8e8d9121-3a47-4c89-9e63-aec6659075d2,VHMLargeIntestine,large intestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
+http://purl.org/ccf/1.5/91009a1d-ddea-4489-af88-3e32ca47cde7,VHMLargeIntestine,large intestine,ascending colon,http://purl.obolibrary.org/obo/UBERON_0001156,1630.0,238660.6,5000
+http://purl.org/ccf/1.5/9a6cb9d5-afdd-429d-98ba-f157a42c7937,VHMLargeIntestine,large intestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
+http://purl.org/ccf/1.5/abab52f8-6fd4-4e3f-8f9c-bb9f5f62785f,VHMLargeIntestine,large intestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
+http://purl.org/ccf/1.5/abab52f8-6fd4-4e3f-8f9c-bb9f5f62785f,VHMLargeIntestine,large intestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
+http://purl.org/ccf/1.5/ba9d007b-c5c7-4231-80f9-42403a98a6df,VHMLargeIntestine,large intestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
+http://purl.org/ccf/1.5/bceacee1-bc17-49ba-ab6f-833a9ccde436,VHMLargeIntestine,large intestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,2680.0,364972.6,5000
+http://purl.org/ccf/1.5/c89a4a3c-52d7-4508-86fb-b7e5610cb1e0,VHMLargeIntestine,large intestine,transverse colon,http://purl.obolibrary.org/obo/UBERON_0001157,2680.0,364972.6,5000
+http://purl.org/ccf/1.5/d3b5feb6-910f-4309-a6a8-42c0477227c9,VHMLargeIntestine,large intestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
+http://purl.org/ccf/1.5/d3b5feb6-910f-4309-a6a8-42c0477227c9,VHMLargeIntestine,large intestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
+http://purl.org/ccf/1.5/df58ff32-e4db-41fe-9a25-47dbde90c694,VHMLargeIntestine,large intestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
+http://purl.org/ccf/1.5/df58ff32-e4db-41fe-9a25-47dbde90c694,VHMLargeIntestine,large intestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
+http://purl.org/ccf/1.5/dfb35d10-65a1-48f9-94a0-baf36ce8a78b,VHMLargeIntestine,large intestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
+http://purl.org/ccf/1.5/dfb35d10-65a1-48f9-94a0-baf36ce8a78b,VHMLargeIntestine,large intestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
+http://purl.org/ccf/1.5/e7d386a6-d4fb-43b2-9737-fdc6f7508d79,VHMLargeIntestine,large intestine,sigmoid colon,http://purl.obolibrary.org/obo/UBERON_0001159,1150.0,80118.31,5000
+http://purl.org/ccf/1.5/e7d386a6-d4fb-43b2-9737-fdc6f7508d79,VHMLargeIntestine,large intestine,rectum,http://purl.obolibrary.org/obo/UBERON_0001052,30.0,55500.6,5000
+http://purl.org/ccf/1.5/fb4cec06-b147-4277-a6cf-8aa21e294183,VHMLargeIntestine,large intestine,descending colon,http://purl.obolibrary.org/obo/UBERON_0001158,1450.0,119090.4,5000
+http://purl.org/ccf/1.5/2990ecc8-1854-4794-8f11-1b31c5c94e5f,VHMLeftKidney,left kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,12,119897.3,12
+http://purl.org/ccf/1.5/29e439fb-cfec-4c2d-a14e-3bc60eb8e255,VHMLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,12,2112.787,12
+http://purl.org/ccf/1.5/29e439fb-cfec-4c2d-a14e-3bc60eb8e255,VHMLeftKidney,left kidney,renal papilla,http://purl.obolibrary.org/obo/UBERON_0001228,3.4079999999999995,29.41792,12
+http://purl.org/ccf/1.5/5166a7a1-bd21-4aa3-ba20-23453cb4c431,VHMLeftKidney,left kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,48,119897.3,48
+http://purl.org/ccf/1.5/72ea5aad-4be7-4478-afc0-7736bc0d90e3,VHMLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,8.244,2112.787,12
+http://purl.org/ccf/1.5/72ea5aad-4be7-4478-afc0-7736bc0d90e3,VHMLeftKidney,left kidney,renal papilla,http://purl.obolibrary.org/obo/UBERON_0001228,11.040000000000001,29.41792,12
+http://purl.org/ccf/1.5/7f7fe1b0-d9f6-48c2-a304-2ea5874c7392,VHMLeftKidney,left kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,1.2,119897.3,30
+http://purl.org/ccf/1.5/7f7fe1b0-d9f6-48c2-a304-2ea5874c7392,VHMLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,30,6220.839,30
+http://purl.org/ccf/1.5/c07ec91d-9dbe-4132-a93c-b960895b009d,VHMLeftKidney,left kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,22.040000000000003,119897.3,40
+http://purl.org/ccf/1.5/c07ec91d-9dbe-4132-a93c-b960895b009d,VHMLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,21.880000000000003,6220.839,40
+http://purl.org/ccf/1.5/cf4ba102-edf7-4fe4-bb1d-860cdf57609d,VHMLeftKidney,left kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,9.2,119897.3,100
+http://purl.org/ccf/1.5/cf4ba102-edf7-4fe4-bb1d-860cdf57609d,VHMLeftKidney,left kidney,renal column,http://purl.obolibrary.org/obo/UBERON_0001284,85.2,39325.43,100
+http://purl.org/ccf/1.5/cf4ba102-edf7-4fe4-bb1d-860cdf57609d,VHMLeftKidney,left kidney,hilum of kidney,http://purl.obolibrary.org/obo/UBERON_0008716,66.10000000000001,7937.076,100
+http://purl.org/ccf/1.5/cf4ba102-edf7-4fe4-bb1d-860cdf57609d,VHMLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,14.299999999999999,3093.173,100
+http://purl.org/ccf/1.5/f31c1726-c693-4734-8c1c-4f1d64bbe034,VHMLeftKidney,left kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,40.5,119897.3,60
+http://purl.org/ccf/1.5/f31c1726-c693-4734-8c1c-4f1d64bbe034,VHMLeftKidney,left kidney,kidney capsule,http://purl.obolibrary.org/obo/UBERON_0002015,5.159999999999999,6251.962,60
+http://purl.org/ccf/1.5/f3f2fabb-6802-4fd4-920e-1914293db252,VHMLeftKidney,left kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,40,119897.3,40
+http://purl.org/ccf/1.5/f3f2fabb-6802-4fd4-920e-1914293db252,VHMLeftKidney,left kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,0.04,6220.839,40
+http://purl.org/ccf/1.5/19fee435-ebad-476c-bc9a-e11d2cee035e,VHMLeftUreter,left ureter,left ureter,http://purl.obolibrary.org/obo/UBERON_0001223,0.568,1685.8,8
+http://purl.org/ccf/1.5/1f414fc5-cb93-45b7-a1b8-0cd21dfa9f7d,VHMLeftUreter,left ureter,left ureter,http://purl.obolibrary.org/obo/UBERON_0001223,0.28,1685.8,8
+http://purl.org/ccf/1.5/3a25960a-8e7a-4020-8dfb-8ce6c3423e35,VHMLeftUreter,left ureter,left ureter,http://purl.obolibrary.org/obo/UBERON_0001223,0.168,1685.8,8
+http://purl.org/ccf/1.5/0364c64a-5b0a-493f-a5ee-3adfc837211c,VHMLung,respiratory system,Left posterior bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7386,1000,240984.7,1000
+http://purl.org/ccf/1.5/0364c64a-5b0a-493f-a5ee-3adfc837211c,VHMLung,respiratory system,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,791.0,174591.4,1000
+http://purl.org/ccf/1.5/0f4be9aa-dfce-414f-9d40-47cb38f5eee8,VHMLung,respiratory system,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,500,309071.6,500
+http://purl.org/ccf/1.5/11fcf508-762d-4f0c-b5c5-dad0cf38f4de,VHMLung,respiratory system,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,500,309071.6,500
+http://purl.org/ccf/1.5/3e6d37df-e4f3-4654-b06d-3a76c2e665ea,VHMLung,respiratory system,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,1003.5000000000001,444225.2,1500
+http://purl.org/ccf/1.5/3e6d37df-e4f3-4654-b06d-3a76c2e665ea,VHMLung,respiratory system,Superior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7374,1500,299217.9,1500
+http://purl.org/ccf/1.5/3e6d37df-e4f3-4654-b06d-3a76c2e665ea,VHMLung,respiratory system,Left anterior segmental bronchus,http://purl.org/sig/ont/fma/fma7428,307.5,4557.781,1500
+http://purl.org/ccf/1.5/527bfb3c-5cea-4131-a73a-72687feb8024,VHMLung,respiratory system,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,996.0,444225.2,1000
+http://purl.org/ccf/1.5/527bfb3c-5cea-4131-a73a-72687feb8024,VHMLung,respiratory system,Left anterior segmental bronchus,http://purl.org/sig/ont/fma/fma7428,26.0,4557.781,1000
+http://purl.org/ccf/1.5/527bfb3c-5cea-4131-a73a-72687feb8024,VHMLung,respiratory system,Left apical segmental bronchus,http://purl.org/sig/ont/fma/fma7426,29.0,1850.033,1000
+http://purl.org/ccf/1.5/56b136e7-40dd-477a-b5b6-9be0bb98374c,VHMLung,respiratory system,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,1000,174591.4,1000
+http://purl.org/ccf/1.5/56b136e7-40dd-477a-b5b6-9be0bb98374c,VHMLung,respiratory system,Left apical segmental bronchus,http://purl.org/sig/ont/fma/fma7426,1.0,1850.033,1000
+http://purl.org/ccf/1.5/594902fb-c4c1-47c3-b98e-3101b93a73e4,VHMLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,295.0,229965.0,500
+http://purl.org/ccf/1.5/594902fb-c4c1-47c3-b98e-3101b93a73e4,VHMLung,respiratory system,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,500,162410.7,500
+http://purl.org/ccf/1.5/5b4b476b-01e1-4d13-95e5-d17770f9ffa9,VHMLung,respiratory system,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,948.0,444225.2,1000
+http://purl.org/ccf/1.5/5b4b476b-01e1-4d13-95e5-d17770f9ffa9,VHMLung,respiratory system,Left posterior bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7386,6.0,240984.7,1000
+http://purl.org/ccf/1.5/5b4b476b-01e1-4d13-95e5-d17770f9ffa9,VHMLung,respiratory system,Left apical segmental bronchus,http://purl.org/sig/ont/fma/fma7426,98.0,1850.033,1000
+http://purl.org/ccf/1.5/616ef33e-ebcc-4ece-b440-ca218440c8b4,VHMLung,respiratory system,Inferior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7375,1750.0,130425.0,2000
+http://purl.org/ccf/1.5/74d8c134-9489-4599-afa7-95bd8cf9fc8a,VHMLung,respiratory system,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,489.5,309071.6,500
+http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,respiratory system,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,2490.0,444225.2,2500
+http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,respiratory system,Superior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7374,95.0,299217.9,2500
+http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,respiratory system,Left anterior segmental bronchus,http://purl.org/sig/ont/fma/fma7428,732.5,4557.781,2500
+http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,respiratory system,Left apical segmental bronchus,http://purl.org/sig/ont/fma/fma7426,7.5,1850.033,2500
+http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,respiratory system,left lung hilus,http://purl.obolibrary.org/obo/UBERON_0004887,434.99999999999994,-14467.8,2500
+http://purl.org/ccf/1.5/76c77da1-c978-48fe-b30b-aeff33a5d054,VHMLung,respiratory system,left lung hilus,http://purl.obolibrary.org/obo/UBERON_0004887,434.99999999999994,-31882.55,2500
+http://purl.org/ccf/1.5/840b29a9-5a04-41cc-908d-0c4fa5720366,VHMLung,respiratory system,Left posterior bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7386,1467.0,240984.7,1500
+http://purl.org/ccf/1.5/840b29a9-5a04-41cc-908d-0c4fa5720366,VHMLung,respiratory system,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,1500,174591.4,1500
+http://purl.org/ccf/1.5/853a9e2c-10ba-4491-9d9d-3551c0c5f26d,VHMLung,respiratory system,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,750,444225.2,750
+http://purl.org/ccf/1.5/853a9e2c-10ba-4491-9d9d-3551c0c5f26d,VHMLung,respiratory system,Superior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7374,728.25,299217.9,750
+http://purl.org/ccf/1.5/8c2283cd-667a-4fa1-9026-50e30bcfdcd1,VHMLung,respiratory system,Superior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7374,1000,299217.9,1000
+http://purl.org/ccf/1.5/8c2283cd-667a-4fa1-9026-50e30bcfdcd1,VHMLung,respiratory system,Inferior lingular bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7375,81.0,130425.0,1000
+http://purl.org/ccf/1.5/8c2283cd-667a-4fa1-9026-50e30bcfdcd1,VHMLung,respiratory system,Superior lingular bronchus,http://purl.org/sig/ont/fma/fma7430,17.0,254.0222,1000
+http://purl.org/ccf/1.5/8d3e8fa1-185d-479b-83d9-9dfe2ead2d3e,VHMLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,1000,229965.0,1000
+http://purl.org/ccf/1.5/95190b47-b491-448a-8e9b-06d804bf2aa1,VHMLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,500,229965.0,500
+http://purl.org/ccf/1.5/95881dfc-b806-40ca-85fd-0e02d647c999,VHMLung,respiratory system,Right Posterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7339,190.0,353229.4,500
+http://purl.org/ccf/1.5/95881dfc-b806-40ca-85fd-0e02d647c999,VHMLung,respiratory system,Right Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7359,483.5,309071.6,500
+http://purl.org/ccf/1.5/95881dfc-b806-40ca-85fd-0e02d647c999,VHMLung,respiratory system,Right superior segmental bronchus,http://purl.org/sig/ont/fma/fma7416,14.5,1456.964,500
+http://purl.org/ccf/1.5/ab2e49b2-1959-44af-8e83-ac16878f6c12,VHMLung,respiratory system,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,1000,174591.4,1000
+http://purl.org/ccf/1.5/aba1ebe3-af18-40cc-b536-b89843049ca5,VHMLung,respiratory system,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,500,162410.7,500
+http://purl.org/ccf/1.5/bb8f70e2-273f-4902-a2ce-70a110aee2ec_AllenWangLungMap_MALE_tissueblock_RUI,VHMLung,respiratory system,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,75,162410.7,75
+http://purl.org/ccf/1.5/bb8f70e2-273f-4902-a2ce-70a110aee2ec_AllenWangLungMap_MALE_tissueblock_RUI,VHMLung,respiratory system,Lateral segmental bronchus,http://purl.org/sig/ont/fma/fma7402,13.65,665.072,75
+http://purl.org/ccf/1.5/c8cdaa06-847b-4747-9a00-d89761cea031,VHMLung,respiratory system,Left apical bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7385,1000,174591.4,1000
+http://purl.org/ccf/1.5/cfa23a23-1cef-4a6f-8303-d1198e91a773,VHMLung,respiratory system,Left posterior bronchopulmonary segment,http://purl.org/sig/ont/fma/fma7386,1000,240984.7,1000
+http://purl.org/ccf/1.5/d51b9d67-837f-4451-a6c6-0b63c7879736,VHMLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,500,229965.0,500
+http://purl.org/ccf/1.5/d662fd53-e925-4921-8d8b-bc91eed1519b,VHMLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,746.25,229965.0,750
+http://purl.org/ccf/1.5/f15f5400-2ef9-45fc-bf0f-72f14d6f8f9e,VHMLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,750,229965.0,750
+http://purl.org/ccf/1.5/f4a116d7-f844-4d4a-bc8f-632151125313,VHMLung,respiratory system,Left Anterior Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7373,1000,444225.2,1000
+http://purl.org/ccf/1.5/fd4fcec2-93c3-428f-ad3a-6c7ac4196da0,VHMLung,respiratory system,Right Medial Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7360,125.0,229965.0,500
+http://purl.org/ccf/1.5/fd4fcec2-93c3-428f-ad3a-6c7ac4196da0,VHMLung,respiratory system,Right Lateral Bronchopulmonary Segment,http://purl.org/sig/ont/fma/fma7361,500,162410.7,500
+http://purl.org/ccf/1.5/5475ae38-db50-4868-92ba-8718bf136c7b,VHMProstate,male reproductive system,peripheral zone of prostate,http://purl.obolibrary.org/obo/UBERON_8410026,319.2,4502.339,700
+http://purl.org/ccf/1.5/5475ae38-db50-4868-92ba-8718bf136c7b,VHMProstate,male reproductive system,peripheral zone of prostate,http://purl.obolibrary.org/obo/UBERON_8410026,320.6,4398.495,700
+http://purl.org/ccf/1.5/5475ae38-db50-4868-92ba-8718bf136c7b,VHMProstate,male reproductive system,central zone of prostate,http://purl.obolibrary.org/obo/UBERON_8410027,33.6,1846.38,700
+http://purl.org/ccf/1.5/5475ae38-db50-4868-92ba-8718bf136c7b,VHMProstate,male reproductive system,central zone of prostate,http://purl.obolibrary.org/obo/UBERON_8410027,30.099999999999998,1753.812,700
+http://purl.org/ccf/1.5/57bab703-98bd-4106-9160-af951a74e4df,VHMRightKidney,right kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,11.328,1911.797,12
+http://purl.org/ccf/1.5/57bab703-98bd-4106-9160-af951a74e4df,VHMRightKidney,right kidney,renal papilla,http://purl.obolibrary.org/obo/UBERON_0001228,5.712,32.27643,12
+http://purl.org/ccf/1.5/69ac0df4-f442-4d62-90dc-86fcbc38eb23,VHMRightKidney,right kidney,renal pyramid,http://purl.obolibrary.org/obo/UBERON_0004200,40,4454.755,40
+http://purl.org/ccf/1.5/6a6392a9-8ac1-4666-a684-83d310ca055f,VHMRightKidney,right kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,120,109925.0,120
+http://purl.org/ccf/1.5/769ca7e9-ead0-4882-966c-d6f5c273c2ee,VHMRightKidney,right kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,180,109925.0,180
+http://purl.org/ccf/1.5/db35f27d-313f-4dd6-819b-375cf106aac1,VHMRightKidney,right kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,12,109925.0,12
+http://purl.org/ccf/1.5/df0b33f7-371a-47a4-a636-a27db19bdbc9,VHMRightKidney,right kidney,outer cortex of kidney,http://purl.obolibrary.org/obo/UBERON_0002189,48,109925.0,48
+http://purl.org/ccf/1.5/314450f7-0477-4152-b4d6-cb474cbc0cd7,VHMSkin,skin of body,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,644.436,2109804.0,7956
+http://purl.org/ccf/1.5/56d63930-60f2-49f5-a3bb-afc8d865c152,VHMSkin,skin of body,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,2352,2109804.0,2352
+http://purl.org/ccf/1.5/cce37703-e4e8-454c-a0c4-4ff58652ab8f,VHMSkin,skin of body,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,1000,2109804.0,1000
+http://purl.org/ccf/1.5/d16014ad-8b92-487b-bca7-044d3d745dba,VHMSkin,skin of body,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,1397.088,2109804.0,2156
+http://purl.org/ccf/1.5/fcfcc65b-f91f-4447-a29b-c9836104570c,VHMSkin,skin of body,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,1008,2109804.0,1008
+http://purl.org/ccf/1.5/ff034c0c-a625-48b8-891c-857e556db1c4,VHMSkin,skin of body,skin of body,http://purl.obolibrary.org/obo/UBERON_0002097,1386,2109804.0,1386
+http://purl.org/ccf/1.5/1f53fe4d-d77b-4508-ba36-22b6b3ac0e53,VHMSmallIntestine,small intestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
+http://purl.org/ccf/1.5/27c90961-5430-4217-ad97-4feaa91cede7,VHMSmallIntestine,small intestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
+http://purl.org/ccf/1.5/2b38ef86-7e4d-4e27-b9c6-d2015ec49692,VHMSmallIntestine,small intestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
+http://purl.org/ccf/1.5/3177d8d7-3b26-4aa3-9984-3c112d461446,VHMSmallIntestine,small intestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
+http://purl.org/ccf/1.5/3177d8d7-3b26-4aa3-9984-3c112d461446,VHMSmallIntestine,small intestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
+http://purl.org/ccf/1.5/42b97dcb-2033-40ea-82a2-319a1e30dca2,VHMSmallIntestine,small intestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
+http://purl.org/ccf/1.5/42b97dcb-2033-40ea-82a2-319a1e30dca2,VHMSmallIntestine,small intestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
+http://purl.org/ccf/1.5/470a6b74-a31b-4a50-bfff-da1b475c945b,VHMSmallIntestine,small intestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
+http://purl.org/ccf/1.5/502f175c-9d55-4341-b6ff-0f04d76522d5,VHMSmallIntestine,small intestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350
+http://purl.org/ccf/1.5/5d35eae0-82df-40c7-952c-6fbab03034b2,VHMSmallIntestine,small intestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
+http://purl.org/ccf/1.5/63b2f5a9-5914-4c45-9239-139948a93498,VHMSmallIntestine,small intestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
+http://purl.org/ccf/1.5/6f055461-adb2-41fe-86c1-50d3afdf9360,VHMSmallIntestine,small intestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
+http://purl.org/ccf/1.5/6f89860a-30df-4b79-8e6d-dd209c959374,VHMSmallIntestine,small intestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
+http://purl.org/ccf/1.5/6fe91946-48bb-485f-9ad0-5f0550d1f2b3,VHMSmallIntestine,small intestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
+http://purl.org/ccf/1.5/75ff443d-c177-4dab-a866-89e9141b73a4,VHMSmallIntestine,small intestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
+http://purl.org/ccf/1.5/75ff443d-c177-4dab-a866-89e9141b73a4,VHMSmallIntestine,small intestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
+http://purl.org/ccf/1.5/78ee24bb-4ae4-49e9-bad2-d6f13166b89e,VHMSmallIntestine,small intestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
+http://purl.org/ccf/1.5/78ee24bb-4ae4-49e9-bad2-d6f13166b89e,VHMSmallIntestine,small intestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
+http://purl.org/ccf/1.5/79a10f00-84e0-4b8e-8622-485973df3773,VHMSmallIntestine,small intestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350
+http://purl.org/ccf/1.5/8023d0ab-338a-43c4-9f9b-d637220f1b8e,VHMSmallIntestine,small intestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350
+http://purl.org/ccf/1.5/85765dd5-2197-4361-b4c6-c9d30186044a,VHMSmallIntestine,small intestine,descending part of duodenum,http://purl.org/sig/ont/fma/fma14928,594.0,10111.84,1800
+http://purl.org/ccf/1.5/a1fc9d45-5af9-4fc4-b2be-340ef0716e09,VHMSmallIntestine,small intestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
+http://purl.org/ccf/1.5/a1fc9d45-5af9-4fc4-b2be-340ef0716e09,VHMSmallIntestine,small intestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
+http://purl.org/ccf/1.5/b09f5826-e6fa-4bec-8054-2fb6e6f202ae,VHMSmallIntestine,small intestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
+http://purl.org/ccf/1.5/bddd9066-3f8c-4330-8e33-23be89ee8a0b,VHMSmallIntestine,small intestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350
+http://purl.org/ccf/1.5/d9aed544-4c6e-42c2-a137-9a9381d8f8c8,VHMSmallIntestine,small intestine,horizontal part of duodenum,http://purl.org/sig/ont/fma/fma14929,351.0,10554.94,1350
+http://purl.org/ccf/1.5/d9aed544-4c6e-42c2-a137-9a9381d8f8c8,VHMSmallIntestine,small intestine,ascending part of duodenum,http://purl.org/sig/ont/fma/fma14930,145.8,7109.89,1350
+http://purl.org/ccf/1.5/e4a44b76-53fd-4c88-9ccf-ba095fcb9673,VHMSmallIntestine,small intestine,distal part of ileum,http://purl.org/sig/ont/fma/fma14966,633.15,14601.44,1350
+http://purl.org/ccf/1.5/ea1d468d-e988-42cd-8e34-71701e568878,VHMSmallIntestine,small intestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350
+http://purl.org/ccf/1.5/fd76b9bb-85b0-4dd0-8e60-7c6ec7c95d73,VHMSmallIntestine,small intestine,jejunum,http://purl.obolibrary.org/obo/UBERON_0002115,463.05,194372.1,1350


### PR DESCRIPTION
@bherr2 
I would like to add a column with the ```organ_label``` synonymous to what we did here: https://github.com/cns-iu/hra-cell-type-populations-supporting-information/blob/main/data-processor/queries/as-datasets-modality.rq#L45-L46. This query, when run, returns empty results. Could you please review? Thanks! 